### PR TITLE
create users

### DIFF
--- a/config/packages/reset_password.yaml
+++ b/config/packages/reset_password.yaml
@@ -1,3 +1,4 @@
 symfonycasts_reset_password:
     request_password_repository: App\Repository\ResetPasswordRequestRepository
     lifetime: 900
+    throttle_limit: 900

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -41,6 +41,7 @@ security:
     access_control:
         - { path: ^/pdf2csv, roles: ROLE_USER }
         - { path: ^/contact, roles: ROLE_USER }
+        - { path: ^/admin, roles: ROLE_ADMIN }
 
     role_hierarchy:
         ROLE_ADMIN: ROLE_USER

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -1,0 +1,54 @@
+<?php
+
+
+/**
+ * Symfony Controller for /admin Route
+ *
+ * PHP version 8.3
+ *
+ * @category  Controller
+ * @package   PDF2CSV
+ * @author    Benjamin Owen <benjamin@projecttiy.com>
+ * @copyright 2024 Benjamin Owen
+ * @license   https://www.gnu.org/licenses/gpl-3.0.en.html#license-text GNU GPLv3
+ * @version   CVS: $Id:$
+ * @link      https://github.com/benowe1717/pdf2csv
+ **/
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * Symfony Controller for /admin Route
+ *
+ * PHP version 8.3
+ *
+ * @category  Controller
+ * @package   PDF2CSV
+ * @author    Benjamin Owen <benjamin@projecttiy.com>
+ * @copyright 2024 Benjamin Owen
+ * @license   https://www.gnu.org/licenses/gpl-3.0.en.html#license-text GNU GPLv3
+ * @version   Release: 0.0.1
+ * @link      https://github.com/benowe1717/pdf2csv
+ **/
+class AdminController extends AbstractController
+{
+    /**
+     * /app_admin Route
+     *
+     * @return Response
+     **/
+    #[Route('/admin', name: 'app_admin')]
+    public function index(): Response
+    {
+        return $this->render(
+            'admin/index.html.twig',
+            [
+                'controller_name' => 'AdminController',
+            ]
+        );
+    }
+}

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -17,8 +17,14 @@
 
 namespace App\Controller;
 
+use App\Entity\User;
+use App\Form\CreateUserType;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Routing\Attribute\Route;
 
 /**
@@ -36,18 +42,83 @@ use Symfony\Component\Routing\Attribute\Route;
  **/
 class AdminController extends AbstractController
 {
+    private EntityManagerInterface $entityManager;
+
+    /**
+     * ResetPasswordController constructor
+     *
+     * @param EntityManagerInterface $entityManager Entity Manager helper
+     **/
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        $this->entityManager = $entityManager;
+    }
+
+    /**
+     * Generate a cryptographically secure random password
+     * for the create-user form. The password doesn't matter
+     * as the user will just reset it anyways
+     *
+     * @return string
+     **/
+    private function generateRandomPassword(): string
+    {
+        $token = bin2hex(random_bytes(16));
+        return hash("sha256", $token);
+    }
+
     /**
      * /app_admin Route
+     *
+     * @param Request                     $request        The http request
+     * @param UserPasswordHasherInterface $passwordHasher Password Hasher
      *
      * @return Response
      **/
     #[Route('/admin', name: 'app_admin')]
-    public function index(): Response
-    {
+    public function index(
+        Request $request,
+        UserPasswordHasherInterface $passwordHasher
+    ): Response {
+        // Start create-user Tab
+        $newUser = new User();
+
+        $createUserForm = $this->createForm(
+            CreateUserType::class,
+            $newUser
+        );
+        $createUserForm->handleRequest($request);
+
+        $errors = $createUserForm->getErrors(true);
+        foreach ($errors as $error) {
+            $this->addFlash('createFormErrors', $error->getMessage());
+        }
+
+        if ($createUserForm->isSubmitted() && $createUserForm->isValid()) {
+            $email = $createUserForm->get('email')->getData();
+            $newUser->setEmail($email);
+            $newUser->setRoles(['ROLE_USER']);
+            $newUser->setPassword(
+                $passwordHasher->hashPassword(
+                    $newUser,
+                    $this->generateRandomPassword()
+                )
+            );
+
+            $this->entityManager->persist($newUser);
+            try {
+                $this->entityManager->flush();
+                $this->addFlash('createFormSuccess', 'User created successfully!');
+                return $this->redirectToRoute('app_admin');
+            } catch (UniqueConstraintViolationException $e) {
+                $this->addFlash('createFormErrors', $e->getMessage());
+            }
+        }
+        // End create-user Tab
         return $this->render(
             'admin/index.html.twig',
             [
-                'controller_name' => 'AdminController',
+                'create_user_form' => $createUserForm,
             ]
         );
     }

--- a/src/Form/CreateUserType.php
+++ b/src/Form/CreateUserType.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * Symfony FormType for User Creation
+ *
+ * PHP version 8.3
+ *
+ * @category  Form
+ * @package   PDF2CSV
+ * @author    Benjamin Owen <benjamin@projecttiy.com>
+ * @copyright 2024 Benjamin Owen
+ * @license   https://www.gnu.org/licenses/gpl-3.0.en.html#license-text GNU GPLv3
+ * @version   CVS: $Id:$
+ * @link      https://github.com/benowe1717/pdf2csv
+ **/
+
+namespace App\Form;
+
+use App\Entity\User;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+/**
+ * Symfony FormType for User Creation
+ *
+ * PHP version 8.3
+ *
+ * @category  Form
+ * @package   PDF2CSV
+ * @author    Benjamin Owen <benjamin@projecttiy.com>
+ * @copyright 2024 Benjamin Owen
+ * @license   https://www.gnu.org/licenses/gpl-3.0.en.html#license-text GNU GPLv3
+ * @version   Release: 0.0.1
+ * @link      https://github.com/benowe1717/pdf2csv
+ **/
+class CreateUserType extends AbstractType
+{
+    /**
+     * Build the Form Interface for the Controller to render
+     *
+     * @param FormBuilderInterface $builder FormBuilderInterface
+     * @param array                $options Options for Form Builder
+     *
+     * @return void
+     **/
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add(
+                'email',
+                TextType::class,
+                [
+                    'label' => 'Email Address',
+                    'constraints' => [
+                        new NotBlank(
+                            [
+                                'message' => 'Email Address cannot be blank!'
+                            ]
+                        )
+                    ]
+                ]
+            )
+            ->add(
+                'submit',
+                SubmitType::class,
+                [
+                    'label' => 'Create',
+                ]
+            );
+    }
+
+    /**
+     * Pass the needed Data Classes to the Form Builder
+     *
+     * @param OptionsResolver $resolver The resolver from Class Objects to Form
+     *
+     * @return void
+     **/
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults(
+            [
+                'data_class' => User::class,
+            ]
+        );
+    }
+}

--- a/src/Form/DeleteUserType.php
+++ b/src/Form/DeleteUserType.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * Symfony FormType for User Deletion
+ *
+ * PHP version 8.3
+ *
+ * @category  Form
+ * @package   PDF2CSV
+ * @author    Benjamin Owen <benjamin@projecttiy.com>
+ * @copyright 2024 Benjamin Owen
+ * @license   https://www.gnu.org/licenses/gpl-3.0.en.html#license-text GNU GPLv3
+ * @version   CVS: $Id:$
+ * @link      https://github.com/benowe1717/pdf2csv
+ **/
+
+namespace App\Form;
+
+use App\Entity\User;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Symfony FormType for User Deletion
+ *
+ * PHP version 8.3
+ *
+ * @category  Form
+ * @package   PDF2CSV
+ * @author    Benjamin Owen <benjamin@projecttiy.com>
+ * @copyright 2024 Benjamin Owen
+ * @license   https://www.gnu.org/licenses/gpl-3.0.en.html#license-text GNU GPLv3
+ * @version   Release: 0.0.1
+ * @link      https://github.com/benowe1717/pdf2csv
+ **/
+class DeleteUserType extends AbstractType
+{
+    /**
+     * Build the Form Interface for the Controller to render
+     *
+     * @param FormBuilderInterface $builder FormBuilderInterface
+     * @param array                $options Options for Form Builder
+     *
+     * @return void
+     **/
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add(
+                'email',
+                EntityType::class,
+                [
+                    'class' => User::class,
+                    'choices' => $options['users'],
+                    'choice_label' => 'email',
+                    'choice_value' => 'id',
+                    'label' => 'Which user do you want to delete?',
+                    'mapped' => false,
+                ]
+            )
+            ->add(
+                'submit',
+                SubmitType::class,
+                [
+                    'label' => 'Delete',
+                ]
+            );
+    }
+
+    /**
+     * Pass the needed Data Classes to the Form Builder
+     *
+     * @param OptionsResolver $resolver The resolver from Class Objects to Form
+     *
+     * @return void
+     **/
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults(
+            [
+                'data_class' => User::class,
+                'users' => User::class,
+            ]
+        );
+    }
+}

--- a/src/Form/ResetPasswordType.php
+++ b/src/Form/ResetPasswordType.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * Symfony FormType for Forced Password Resets
+ *
+ * PHP version 8.3
+ *
+ * @category  Form
+ * @package   PDF2CSV
+ * @author    Benjamin Owen <benjamin@projecttiy.com>
+ * @copyright 2024 Benjamin Owen
+ * @license   https://www.gnu.org/licenses/gpl-3.0.en.html#license-text GNU GPLv3
+ * @version   CVS: $Id:$
+ * @link      https://github.com/benowe1717/pdf2csv
+ **/
+
+namespace App\Form;
+
+use App\Entity\User;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Symfony FormType for Forced Password Resets
+ *
+ * PHP version 8.3
+ *
+ * @category  Form
+ * @package   PDF2CSV
+ * @author    Benjamin Owen <benjamin@projecttiy.com>
+ * @copyright 2024 Benjamin Owen
+ * @license   https://www.gnu.org/licenses/gpl-3.0.en.html#license-text GNU GPLv3
+ * @version   Release: 0.0.1
+ * @link      https://github.com/benowe1717/pdf2csv
+ **/
+class ResetPasswordType extends AbstractType
+{
+    /**
+     * Build the Form Interface for the Controller to render
+     *
+     * @param FormBuilderInterface $builder FormBuilderInterface
+     * @param array                $options Options for Form Builder
+     *
+     * @return void
+     **/
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add(
+                'email',
+                EntityType::class,
+                [
+                    'class' => User::class,
+                    'choice_label' => 'email',
+                    'choice_value' => 'id',
+                    'label' => 'Which user do you want to reset the password for?',
+                    'mapped' => false,
+                ]
+            )
+            ->add(
+                'submit',
+                SubmitType::class,
+                [
+                    'label' => 'Reset Password',
+                ]
+            );
+    }
+
+    /**
+     * Pass the needed Data Classes to the Form Builder
+     *
+     * @param OptionsResolver $resolver The resolver from Class Objects to Form
+     *
+     * @return void
+     **/
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults(
+            [
+                'data_class' => User::class,
+            ]
+        );
+    }
+}

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -1,5 +1,19 @@
 <?php
 
+/**
+ * Doctrine Repository for User Entity
+ *
+ * PHP version 8.3
+ *
+ * @category  Repository
+ * @package   PDF2CSV
+ * @author    Benjamin Owen <benjamin@projecttiy.com>
+ * @copyright 2024 Benjamin Owen
+ * @license   https://www.gnu.org/licenses/gpl-3.0.en.html#license-text GNU GPLv3
+ * @version   CVS: $Id:$
+ * @link      https://github.com/benowe1717/pdf2csv
+ **/
+
 namespace App\Repository;
 
 use App\Entity\User;
@@ -10,10 +24,26 @@ use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\PasswordUpgraderInterface;
 
 /**
- * @extends ServiceEntityRepository<User>
- */
+ * Doctrine Repository for User Entity
+ *
+ * PHP version 8.3
+ *
+ * @category  Repository
+ * @package   PDF2CSV
+ * @author    Benjamin Owen <benjamin@projecttiy.com>
+ * @copyright 2024 Benjamin Owen
+ * @license   https://www.gnu.org/licenses/gpl-3.0.en.html#license-text GNU GPLv3
+ * @version   Release: 0.0.1
+ * @link      https://github.com/benowe1717/pdf2csv
+ * @extends   ServiceEntityRepository<User>
+ **/
 class UserRepository extends ServiceEntityRepository implements PasswordUpgraderInterface
 {
+    /**
+     * UserRepository constructor
+     *
+     * @param ManagerRegistry $registry ManagerRegistry
+     **/
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, User::class);
@@ -21,16 +51,42 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
 
     /**
      * Used to upgrade (rehash) the user's password automatically over time.
+     *
+     * @param PasswordAuthenticatedUserInterface $user              The user object
+     * @param string                             $newHashedPassword The new hash
+     *
+     * @return void
      */
-    public function upgradePassword(PasswordAuthenticatedUserInterface $user, string $newHashedPassword): void
-    {
+    public function upgradePassword(
+        PasswordAuthenticatedUserInterface $user,
+        string $newHashedPassword
+    ): void {
         if (!$user instanceof User) {
-            throw new UnsupportedUserException(sprintf('Instances of "%s" are not supported.', $user::class));
+            throw new UnsupportedUserException(
+                sprintf(
+                    'Instances of "%s" are not supported.',
+                    $user::class
+                )
+            );
         }
 
         $user->setPassword($newHashedPassword);
         $this->getEntityManager()->persist($user);
         $this->getEntityManager()->flush();
+    }
+
+    /**
+     * Get all non-admin users in the system
+     *
+     * @return User[]
+     **/
+    public function getAllUnprivilegedUsers(): array
+    {
+        return $this->createQueryBuilder('u')
+            ->andWhere('u.roles NOT LIKE :role')
+            ->setParameter('role', '%ROLE_ADMIN%')
+            ->getQuery()
+            ->getResult();
     }
 
     //    /**

--- a/templates/_navbar.html.twig
+++ b/templates/_navbar.html.twig
@@ -28,6 +28,11 @@
                 <li class="nav-item">
                     <a class="nav-link {{ route == 'app_contact' ? 'active' }}" href="{{ path('app_contact') }}">Contact</a>
                 </li>
+                    {% if is_granted('ROLE_ADMIN') %}
+                    <li class="nav-item">
+                        <a class="nav-link {{ route == 'app_admin' ? 'active' }}" href="{{ path('app_admin') }}">Admin</a>
+                    </li>
+                    {% endif %}
                 {% endif %}
             </ul>
 

--- a/templates/admin/create_user.html.twig
+++ b/templates/admin/create_user.html.twig
@@ -1,0 +1,8 @@
+<div class="px-3 py-3 justify-content-start text-start">
+    <form method="post" action="">
+        <div class="mb-3">
+            <label class="form-label">Email Address</label>
+            <input class="form-control" type="email" autofocus required>
+        </div>
+    </form>
+</div>

--- a/templates/admin/create_user.html.twig
+++ b/templates/admin/create_user.html.twig
@@ -1,8 +1,12 @@
 <div class="px-3 py-3 justify-content-start text-start">
-    <form method="post" action="">
+    <form method="{{ create_user_form.vars.method }}" id="{{ create_user_form.vars.id }}" name="{{ create_user_form.vars.full_name }}" action="{{ create_user_form.vars.action }}">
         <div class="mb-3">
-            <label class="form-label">Email Address</label>
-            <input class="form-control" type="email" autofocus required>
+            <label class="form-label" for="{{ create_user_form.email.vars.id }}">{{ create_user_form.email.vars.label }}</label>
+            <input class="form-control" id="{{ create_user_form.email.vars.id }}" name="{{ create_user_form.email.vars.full_name }}" value="{{ create_user_form.email.vars.value }}" type="email" placeholder="Email" autofocus required>
         </div>
+        <div class="mb-3">
+            <button class="btn btn-primary" id="{{ create_user_form.submit.vars.id }}" name="{{ create_user_form.submit.vars.full_name }}" type="submit">{{ create_user_form.submit.vars.label }}</button>
+        </div>
+        <input id="{{ create_user_form._token.vars.id }}" name="{{ create_user_form._token.vars.full_name }}" value="{{ create_user_form._token.vars.value }}" type="hidden">
     </form>
 </div>

--- a/templates/admin/delete_user.html.twig
+++ b/templates/admin/delete_user.html.twig
@@ -1,0 +1,8 @@
+<div class="px-3 py-3 justify-content-start text-start">
+    <form method="post" action="">
+        <div class="mb-3">
+            <label class="form-label">Email Address</label>
+            <input class="form-control" type="email" autofocus required>
+        </div>
+    </form>
+</div>

--- a/templates/admin/delete_user.html.twig
+++ b/templates/admin/delete_user.html.twig
@@ -1,8 +1,16 @@
 <div class="px-3 py-3 justify-content-start text-start">
-    <form method="post" action="">
+    <form method="{{ delete_user_form.vars.method }}" id="{{ delete_user_form.vars.id }}" name="{{ delete_user_form.vars.full_name }}" action="{{ delete_user_form.vars.action }}">
         <div class="mb-3">
-            <label class="form-label">Email Address</label>
-            <input class="form-control" type="email" autofocus required>
+            <label class="form-label" for="{{ delete_user_form.email.vars.id }}">{{ delete_user_form.email.vars.label }}</label>
+            <select class="form-select" id="{{ delete_user_form.email.vars.id }}" name="{{ delete_user_form.email.vars.full_name }}">
+                {% for choice in delete_user_form.email.vars.choices %}
+                <option value="{{ choice.value }}">{{ choice.label }}</option>
+                {% endfor %}
+            </select>
         </div>
+        <div class="mb-3">
+            <button class="btn btn-danger" id="{{ delete_user_form.submit.vars.id }}" name="{{ delete_user_form.submit.vars.full_name }}" type="submit">{{ delete_user_form.submit.vars.label }}</button>
+        </div>
+        <input id="{{ delete_user_form._token.vars.id }}" name="{{ delete_user_form._token.vars.full_name }}" value="{{ delete_user_form._token.vars.value }}" type="hidden">
     </form>
 </div>

--- a/templates/admin/index.html.twig
+++ b/templates/admin/index.html.twig
@@ -30,6 +30,18 @@
             <p>{{ msg }}</p>
         </div>
         {% endfor %}
+
+        {% for error in app.flashes('resetFormErrors') %}
+        <div class="alert alert-danger">
+            <p>{{ error }}</p>
+        </div>
+        {% endfor %}
+
+        {% for msg in app.flashes('resetFormSuccess') %}
+        <div class="alert alert-success">
+            <p>{{ msg }}</p>
+        </div>
+        {% endfor %}
     </div>
 
     <div class="col-lg-6 mx-auto">

--- a/templates/admin/index.html.twig
+++ b/templates/admin/index.html.twig
@@ -18,6 +18,18 @@
             <p>{{ msg }}</p>
         </div>
         {% endfor %}
+
+        {% for error in app.flashes('deleteFormErrors') %}
+        <div class="alert alert-danger">
+            <p>{{ error }}</p>
+        </div>
+        {% endfor %}
+
+        {% for msg in app.flashes('deleteFormSuccess') %}
+        <div class="alert alert-success">
+            <p>{{ msg }}</p>
+        </div>
+        {% endfor %}
     </div>
 
     <div class="col-lg-6 mx-auto">

--- a/templates/admin/index.html.twig
+++ b/templates/admin/index.html.twig
@@ -5,6 +5,21 @@
 {% block body %}
 <div class="px-4 py-5 my-5 text-center">
     <h1 class="display-5 fw-bold text-body-emphasis mb-3">User Administration</h1>
+
+    <div class="col-lg-6 mx-auto text-start">
+        {% for error in app.flashes('createFormErrors') %}
+        <div class="alert alert-danger">
+            <p>{{ error }}</p>
+        </div>
+        {% endfor %}
+
+        {% for msg in app.flashes('createFormSuccess') %}
+        <div class="alert alert-success">
+            <p>{{ msg }}</p>
+        </div>
+        {% endfor %}
+    </div>
+
     <div class="col-lg-6 mx-auto">
         <ul class="nav nav-tabs flex-column flex-md-row" id="adminTabs" role="tablist">
             <li class="nav-item text-sm-center" role="presentation">

--- a/templates/admin/index.html.twig
+++ b/templates/admin/index.html.twig
@@ -1,20 +1,28 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Hello AdminController!{% endblock %}
+{% block title %}Admin{% endblock %}
 
 {% block body %}
-<style>
-    .example-wrapper { margin: 1em auto; max-width: 800px; width: 95%; font: 18px/1.5 sans-serif; }
-    .example-wrapper code { background: #F5F5F5; padding: 2px 6px; }
-</style>
+<div class="px-4 py-5 my-5 text-center">
+    <h1 class="display-5 fw-bold text-body-emphasis mb-3">User Administration</h1>
+    <div class="col-lg-6 mx-auto">
+        <ul class="nav nav-tabs flex-column flex-md-row" id="adminTabs" role="tablist">
+            <li class="nav-item text-sm-center" role="presentation">
+                <button class="nav-link active" id="create-user" data-bs-toggle="tab" data-bs-target="#create-user-pane" type="button" role="tab" aria-controls="create-user-pane" aria-selected="true">Create User?</button>
+            </li>
+            <li class="nav-item text-sm-center" role="presentation">
+                <button class="nav-link" id="delete-user" data-bs-toggle="tab" data-bs-target="#delete-user-pane" type="button" role="tab" aria-controls="delete-user-pane" aria-selected="false">Delete User?</button>
+            </li>
+            <li class="nav-item text-sm-center" role="presentation">
+                <button class="nav-link" id="reset-password" data-bs-toggle="tab" data-bs-target="#reset-password-pane" type="button" role="tab" aria-controls="reset-password-pane" aria-selected="false">Reset Password?</button>
+            </li>
+        </ul>
 
-<div class="example-wrapper">
-    <h1>Hello {{ controller_name }}! ✅</h1>
-
-    This friendly message is coming from:
-    <ul>
-        <li>Your controller at <code>/home/benjamin/Documents/github/pdf2csv/src/Controller/AdminController.php</code></li>
-        <li>Your template at <code>/home/benjamin/Documents/github/pdf2csv/templates/admin/index.html.twig</code></li>
-    </ul>
+        <div class="tab-content" id="adminTabsContent">
+            <div class="tab-pane fade show active" id="create-user-pane" role="tabpanel" aria-labelledby="create-user" tabindex="0">{{ include('admin/create_user.html.twig') }}</div>
+            <div class="tab-pane fade" id="delete-user-pane" role="tabpanel" aria-labelledby="delete-user" tabindex="0">{{ include('admin/delete_user.html.twig') }}</div>
+            <div class="tab-pane fade" id="reset-password-pane" role="tabpanel" aria-labelledby="reset-password" tabindex="0">{{ include('admin/reset_password.html.twig') }}</div>
+        </div>
+    </div>
 </div>
 {% endblock %}

--- a/templates/admin/index.html.twig
+++ b/templates/admin/index.html.twig
@@ -1,0 +1,20 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Hello AdminController!{% endblock %}
+
+{% block body %}
+<style>
+    .example-wrapper { margin: 1em auto; max-width: 800px; width: 95%; font: 18px/1.5 sans-serif; }
+    .example-wrapper code { background: #F5F5F5; padding: 2px 6px; }
+</style>
+
+<div class="example-wrapper">
+    <h1>Hello {{ controller_name }}! ✅</h1>
+
+    This friendly message is coming from:
+    <ul>
+        <li>Your controller at <code>/home/benjamin/Documents/github/pdf2csv/src/Controller/AdminController.php</code></li>
+        <li>Your template at <code>/home/benjamin/Documents/github/pdf2csv/templates/admin/index.html.twig</code></li>
+    </ul>
+</div>
+{% endblock %}

--- a/templates/admin/reset_password.html.twig
+++ b/templates/admin/reset_password.html.twig
@@ -1,8 +1,22 @@
 <div class="px-3 py-3 justify-content-start text-start">
-    <form method="post" action="">
+    <form method="{{ reset_user_form.vars.method }}" id="{{ reset_user_form.vars.id }}" name="{{ reset_user_form.vars.full_name }}" action="{{ reset_user_form.vars.action }}">
         <div class="mb-3">
-            <label class="form-label">Email Address</label>
-            <input class="form-control" type="email" autofocus required>
+            <label class="form-label" for="{{ reset_user_form.email.vars.id }}">{{ reset_user_form.email.vars.label }}</label>
+            <select class="form-select" id="{{ reset_user_form.email.vars.id }}" name="{{ reset_user_form.email.vars.full_name }}">
+                {% for choice in reset_user_form.email.vars.choices %}
+                <option value="{{ choice.value }}">{{ choice.label }}</option>
+                {% endfor %}
+            </select>
         </div>
+        <div class="mb-3">
+            <button class="btn btn-danger" id="{{ reset_user_form.submit.vars.id }}" name="{{ reset_user_form.submit.vars.full_name }}" type="submit">{{ reset_user_form.submit.vars.label }}</button>
+        </div>
+        <input id="{{ reset_user_form._token.vars.id }}" name="{{ reset_user_form._token.vars.full_name }}" value="{{ reset_user_form._token.vars.value }}" type="hidden">
     </form>
+
+    <div class="px-3 py-3 justify-content-start text-start">
+        {% for reset_token in app.flashes('reset_token') %}
+        <p class="lead">The user's reset password link is: {{ url('app_reset_password', {token: reset_token}) }}</p>
+        {% endfor %}
+    </div>
 </div>

--- a/templates/admin/reset_password.html.twig
+++ b/templates/admin/reset_password.html.twig
@@ -1,0 +1,8 @@
+<div class="px-3 py-3 justify-content-start text-start">
+    <form method="post" action="">
+        <div class="mb-3">
+            <label class="form-label">Email Address</label>
+            <input class="form-control" type="email" autofocus required>
+        </div>
+    </form>
+</div>

--- a/templates/admin/welcome_email.html.twig
+++ b/templates/admin/welcome_email.html.twig
@@ -1,0 +1,21 @@
+{% apply inline_css(source('@styles/app.output.css')) %}
+<div class="px-4 py-5 my-5">
+    <p class="fw-bold text-center text-wrap mb-2">Welcome to...</p>
+    <h1 class="fw-bold text-center text-wrap mb-2">PDF to CSV</h1>
+    <h4 class="fw-bold text-center text-wrap mb-4">by Project TIY</h4>
+
+    <div class="col-lg-6 mx-auto text-start">
+        <p class="lead mb-4">An account has just been created for you! Please see the details below:</p>
+        <p class="lead mb-2"><strong>Username</strong>: {{ username }}</p>
+        <p class="lead mb-4">
+            <strong>Password</strong>: <a class="link-warning" href="{{ url('app_reset_password', {token: welcome_token}) }}">{{ url('app_reset_password', {token: welcome_token}) }}</a>
+        </p>
+    </div>
+
+    <div class="col-lg-6 mx-auto text-start">
+        <p class="lead mb-4">This link will expire in <strong>{{ expiration_key|trans(expiration_message, 'ResetPasswordBundle') }}</strong>.</p>
+        <p class="lead mb-4">If you couldn't get to this link in time, do not worry! Simply navigate to <a class="link-primary" href="{{ url('app_forgot_password_request') }}">this link</a> to start the Password Reset process.</p>
+    </div>
+
+</div>
+{% endapply %}


### PR DESCRIPTION
- ran `php bin/console make:controller` to get the app_admin route created
- updated security package configuration to only allow users with ROLE_ADMIN access to the app_admin route
- updated _navbag twig partial to include the app_admin route only if the role is ROLE_ADMIN
- updated app_admin route ui design
- added three supporting templates to abstract the ui for each tab into their own template to make updating easier
- added new CreateUserType form for creating a user
- updated AdminController to handle rendering the new form and doing work to create the submitted user
- updated create_user twig template with new form
- updated admin/index twig template with the ability to display error and success messages
- added new DeleteUserType form for deleting a user
- updated AdminController to handle rendering the new form and doing work to delete the requested user
- updated delete_user twig template with new form
- updated admin/index twig template with the ability to display error and success messages
- added new ResetPasswordType form for resetting the password for a user
- updated AdminController to handle rendering the new form and doing work to reset the password of the requested user
- updated reset_password twig template with new form
- updated admin/index twig template with the ability to display error and success messages
- added a welcome_email twig template
- updated AdminController to support sending a welcome email after the new user is created to help facilitate getting the user logged in easier
- updated reset_password config to make the threshold the same as the lifetime

closes #11 