### PR TITLE
production readiness pt. 2

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -2,8 +2,9 @@
 
 PHP=`which php`
 COMPOSER=`which composer`
+NOHUP=`which nohup`
 
-BINARIES=("php" "composer")
+BINARIES=("php" "composer" "nohup")
 WORKERS=("async" "scheduler_main")
 TIME_LIMIT="3600"
 
@@ -19,7 +20,7 @@ done
 
 $COMPOSER dump-env $APP_ENV
 $COMPOSER install --no-dev --optimize-autoloader
-$PHP ./bin/console doctrine:migrations:migrate
+$PHP ./bin/console doctrine:migrations:migrate --no-interaction
 $PHP ./bin/console importmap:install
 $PHP ./bin/console sass:build
 $PHP ./bin/console asset-map:compile
@@ -27,5 +28,5 @@ $PHP ./bin/console cache:clear
 
 # Now start up workers to consume the messages
 for worker in "${WORKERS[@]}"; do
-    ./start_worker.sh "$worker" "$TIME_LIMIT"
+    $NOHUP ./start_worker.sh "$worker" "$TIME_LIMIT" &
 done

--- a/migrations/Version20241021014622.php
+++ b/migrations/Version20241021014622.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * Custom Doctrine Migration used to create PdfTypes in Production
+ *
+ * PHP version 8.3
+ *
+ * @category  Doctrine:Migration
+ * @package   PDF2CSV
+ * @author    Benjamin Owen <benjamin@projecttiy.com>
+ * @copyright 2024 Benjamin Owen
+ * @license   https://www.gnu.org/licenses/gpl-3.0.en.html#license-text GNU GPLv3
+ * @version   CVS: $Id:$
+ * @link      https://github.com/benowe1717/pdf2csv
+ **/
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Custom Doctrine Migration used to create PdfTypes in Production
+ *
+ * PHP version 8.3
+ *
+ * @category  Doctrine:Migration
+ * @package   PDF2CSV
+ * @author    Benjamin Owen <benjamin@projecttiy.com>
+ * @copyright 2024 Benjamin Owen
+ * @license   https://www.gnu.org/licenses/gpl-3.0.en.html#license-text GNU GPLv3
+ * @version   Release: 0.0.1
+ * @link      https://github.com/benowe1717/pdf2csv
+ **/
+final class Version20241021014622 extends AbstractMigration
+{
+    /**
+     * Gets the description of this database migration
+     *
+     * @return string
+     **/
+    public function getDescription(): string
+    {
+        return 'Creates PdfTypes in production';
+    }
+
+    /**
+     * Runs with the --up flag during migrations to CREATE objects
+     *
+     * @param Schema $schema The database schema
+     *
+     * @return void
+     **/
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('INSERT IGNORE INTO pdf_types SET name = "InvoiceRegister"');
+        $this->addSql('INSERT IGNORE INTO pdf_types SET name = "GeneralJournal"');
+    }
+
+    /**
+     * Runs with the --down flag during migrations to REMOVE objects
+     *
+     * @param Schema $schema The database schema
+     *
+     * @return void
+     **/
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+    }
+}


### PR DESCRIPTION
- updated `deploy.sh` with nohup syntax to better handle starting multiple workers
- updated `deploy.sh` with a switch for the doctrine migrations command to not prompt for input during deployment
- created doctrine migration to add pdftypes into production database